### PR TITLE
Fix angle ranges in the spec.

### DIFF
--- a/spec-source-orientation.html
+++ b/spec-source-orientation.html
@@ -434,7 +434,7 @@ cite this document as other than work in progress.</p>
 
   <ol id="rotations">
     <li>
-      <p>Rotate the device frame around its z axis by <code>alpha</code> degrees, with <code>alpha</code> in [0, 360].</p>
+      <p>Rotate the device frame around its z axis by <code>alpha</code> degrees, with <code>alpha</code> in [0, 360).</p>
       <div>
         <img src="start.png" alt="start orientation">
         <div>Device in the initial position, with Earth (XYZ) and body (xyz) frames aligned.</div>
@@ -445,14 +445,14 @@ cite this document as other than work in progress.</p>
       </div>
     </li>
     <li>
-      <p>Rotate the device frame around its x axis by <code>beta</code> degrees, with <code>beta</code> in [-180, 180].</p>
+      <p>Rotate the device frame around its x axis by <code>beta</code> degrees, with <code>beta</code> in [-180, 180).</p>
       <div>
         <img src="a-rotation.png" alt="rotation about x axis">
         <div>Device rotated through angle beta about new x axis, with previous locations of y and z axes shown as y<sub>0</sub> and z<sub>0</sub>.</div>
       </div>
     </li>
     <li>
-      <p>Rotate the device frame around its y axis by <code>gamma</code> degrees, with <code>gamma</code> in [-90, 90].</p>
+      <p>Rotate the device frame around its y axis by <code>gamma</code> degrees, with <code>gamma</code> in [-90, 90).</p>
       <div>
         <img src="b-rotation.png" alt="rotation about y axis">
         <div>Device rotated through angle gamma about new y axis, with previous locations of x and z axes shown as x<sub>0</sub> and z<sub>0</sub>.</div>
@@ -581,7 +581,7 @@ cite this document as other than work in progress.</p>
 
   <p>The <code>rotationRate</code> attribute must be initialized with the rate of rotation of
   the hosting device in space. It must be expressed as the rate of change of
-  the angles of those defined in <a href="#deviceorientation">section 4.1</a> and
+  the angles defined in <a href="#deviceorientation">section 4.1</a> and
   must be expressed in degrees per second (deg/s).
 
   <p>The <code>interval</code> attribute must be initialized with the interval at which


### PR DESCRIPTION
To avoid ambiguity the angle range intervals should be open on one side.
Also removed some unnecessary words to simplify the sentence.
