### PR TITLE
Add deviceorientation and devicemotion feature detection conformance requirement

### DIFF
--- a/spec-source-orientation.html
+++ b/spec-source-orientation.html
@@ -205,6 +205,16 @@ cite this document as other than work in progress.</p>
   <a href="#ref-domevents">[DOM4]</a>.
   Implementations must therefore support this specification.
 
+  <p>When support for a feature is disabled (e.g. as an emergency measure to
+   mitigate a security problem, due to lack of sensor support in the current
+   platform, to aid in development, or for performance reasons), user agents
+   <em class="rfc2119" title="MUST">MUST</em> act as if they had no support for
+   the feature whatsoever, and as if the feature was not mentioned in this
+   specification. For example, if a particular feature is accessed via an
+   attribute in a Web IDL interface, the attribute itself would be omitted from
+   the objects that implement that interface - leaving the attribute on the
+   object but making it return null or throw an exception is insufficient.
+
   <h2 id="introduction"><span class=secno>2 </span>Introduction</h2>
 
   <p><em>This section is non-normative.</em>


### PR DESCRIPTION
We need a way to reliably check if DeviceOrientation and DeviceMotion events are supported in the current user agent.

This addition requires user agents not to expose `window.DeviceOrientationEvent` or `window.DeviceMotionEvent` interfaces if the respective sensors required by their events implementation is not available. That is to say, we would then be able to reliably check if these events are supported as follows:

```
if (window.DeviceOrientationEvent) {
  // current UA supports DeviceOrientation events. Register our 'deviceorientation' event listener here.
} else {
  // current UA does not support DeviceOrientation events. Provide fallback user controls here.
}
```

and:

```
if (window.DeviceMotionEvent) {
  // current UA supports DeviceMotion events. Register our 'devicemotion' event listener here.
} else {
  // current UA does not support DeviceMotion events. Provide fallback user controls here.
}
```

This is inline with conformance requirements used elsewhere in the web platform e.g. in the HTML specification (see the last paragraph of https://html.spec.whatwg.org/multipage/infrastructure.html#extensibility-2).
