### PR TITLE
Use HTTPS as needed to avoid mixed content warnings

### DIFF
--- a/spec-source-orientation.html
+++ b/spec-source-orientation.html
@@ -48,17 +48,17 @@
    ol#rotations li div img { width: 350px; }
    object.equation { display: block; margin: 20px 20px; width: 100%; height: inherit; }
   </style>
-  <link href="http://www.w3.org/StyleSheets/TR/W3C-ED.css" rel=stylesheet type="text/css">
+  <link href="https://www.w3.org/StyleSheets/TR/W3C-ED.css" rel=stylesheet type="text/css">
  </head>
 
  <body>
   <div class=head> <!--begin-logo-->
    <p><a href="http://www.w3.org/"><img alt="W3C" height="48"
-    src="http://www.w3.org/Icons/w3c_home" width=72></a> <!--end-logo-->
+    src="https://www.w3.org/Icons/w3c_home" width=72></a> <!--end-logo-->
 
    <h1 id="title_heading">DeviceOrientation Event Specification</h1>
 
-   <h2 class="no-num no-toc" id="draft_date">Editor's Draft 12 November 2015</h2>
+   <h2 class="no-num no-toc" id="draft_date">Editor's Draft 26 February 2016</h2>
 
    <dl>
     <!-- <dt>This Version:</dt>


### PR DESCRIPTION
This changes only the bare minimum necessary, there are many links in
the document that could be HTTPS but are not.