### PR TITLE
Make interval IDL consistent with normative text.

### DIFF
--- a/spec-source-orientation.html
+++ b/spec-source-orientation.html
@@ -589,7 +589,7 @@ cite this document as other than work in progress.</p>
       readonly attribute DeviceAcceleration? acceleration;
       readonly attribute DeviceAcceleration? accelerationIncludingGravity;
       readonly attribute DeviceRotationRate? rotationRate;
-      readonly attribute double? interval;
+      readonly attribute double interval;
     };
 
     dictionary DeviceAccelerationInit {
@@ -608,7 +608,7 @@ cite this document as other than work in progress.</p>
       DeviceAccelerationInit? acceleration;
       DeviceAccelerationInit? accelerationIncludingGravity;
       DeviceRotationRateInit? rotationRate;
-      double? interval = null;
+      double interval = 0;
     };
   </pre>
 


### PR DESCRIPTION
This change makes the IDL for the DeviceMotionEvent.interval consistent with the normative description of this attribute, which requires it to be initialized to 0 if not specified. This implies that this attribute should not be nullable and simply have a default value of 0.

Resolves #39.