### PR TITLE
Update spec metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,12 +53,11 @@
 
  <body>
   <div class=head> <!--begin-logo-->
-   <p><a href="http://www.w3.org/"><img alt="W3C" height="48"
-    src="https://www.w3.org/Icons/w3c_home" width=72></a> <!--end-logo-->
+   <p><a href="https://www.w3.org/"><img height="48" width="72" alt="W3C" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C"/></a> <!--end-logo-->
 
    <h1 id="title_heading">DeviceOrientation Event Specification</h1>
 
-   <h2 class="no-num no-toc" id="draft_date">Editor's Draft 1 July 2016</h2>
+   <h2 class="no-num no-toc" id="draft_date">Editor's Draft 15 August 2018</h2>
 
    <dl>
     <!-- <dt>This Version:</dt>
@@ -93,7 +92,9 @@
 
    </dl>
 
-   <p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2011 <a href="http://www.w3.org/"><acronym title="World Wide Web Consortium">W3C</acronym></a><sup>&reg;</sup> (<a href="http://www.csail.mit.edu/"><acronym title="Massachusetts Institute of Technology">MIT</acronym></a>, <a href="http://www.ercim.eu/"><acronym title="European Research Consortium for Informatics and Mathematics">ERCIM</acronym></a>, <a href="http://www.keio.ac.jp/">Keio</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2018 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply. </p>
+
+   <p> This document is governed by the <a href="https://www.w3.org/2018/Process-20180201/" id="w3c_process_revision">1 February 2018 W3C Process Document</a>. </p>
 
    <hr>
   </div>
@@ -134,14 +135,13 @@ cite this document as other than work in progress.</p>
 <p>This is the First Public Working draft of this specification. <b>It should not be considered stable.</b>  When providing feedback, please first refer to the <a href="https://w3c.github.io/deviceorientation/">Editor's Draft</a> and confirm that the issue has not been addressed already.  If the issue has not been addressed, please describe it on the <a href="http://lists.w3.org/Archives/Public/public-geolocation/">public mailing list</a>.</p>
 
   <p> This document was produced by a group operating under the <a
-   href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February
-   2004 W3C Patent Policy</a>. W3C maintains a <a href="http://www.w3.org/2004/01/pp-impl/42891/status" rel="disclosure">public list of any patent disclosures</a>
+   href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>. W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/43696/status" rel="disclosure">public list of any patent disclosures</a>
    made in connection with the deliverables of the group; that page also
    includes instructions for disclosing a patent. An individual who has
    actual knowledge of a patent which the individual believes contains <a
-   href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
+   href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential
    Claim(s)</a> must disclose the information in accordance with <a
-   href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
+   href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section
    6 of the W3C Patent Policy</a>.
 
   <h2 class="no-num no-toc" id="contents">Table of Contents</h2>

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
     <dd><a href="https://github.com/w3c/deviceorientation">We are on GitHub</a></dd>
     <dd><a href="https://github.com/w3c/deviceorientation/issues">File a bug</a></dd>
     <dd><a href="https://github.com/w3c/deviceorientation/commits">Commit history</a></dd>
-    <dd><a href="https://lists.w3.org/Archives/Public/public-geolocation/">Mailing list</a></dd>
+    <dd><a href="https://lists.w3.org/Archives/Public/public-device-apis/">Mailing list</a></dd>
 
    </dl>
 
@@ -116,13 +116,13 @@ http://www.w3.org/TR/.</em></p>
   <!-- where to send feedback (required) -->
 
   <p>This document was published by the <a
-  href="http://www.w3.org/2008/geolocation/">Geolocation Working Group</a>.
+  href="https://www.w3.org/das/">Devices and Sensors Working Group</a>.
   If you wish to make comments regarding this document, please send
   them to <a
-  href="mailto:public-geolocation@w3.org">public-geolocation@w3.org</a> (<a
-  href="mailto:public-geolocation-request@w3.org?subject=subscribe">subscribe</a>,
+  href="mailto:public-device-apis@w3.org">public-device-apis@w3.org</a> (<a
+  href="mailto:public-device-apis-request@w3.org?subject=subscribe">subscribe</a>,
   <a
-  href="http://lists.w3.org/Archives/Public/public-geolocation/">archives</a>).</p>
+  href="http://lists.w3.org/Archives/Public/public-device-apis/">archives</a>).</p>
   <p>All feedback is welcome.</p>
   <!-- stability (required) -->
 
@@ -132,7 +132,7 @@ or obsoleted by other documents at any time. It is inappropriate to
 cite this document as other than work in progress.</p>
 
   <!-- required patent boilerplate -->
-<p>This is the First Public Working draft of this specification. <b>It should not be considered stable.</b>  When providing feedback, please first refer to the <a href="https://w3c.github.io/deviceorientation/">Editor's Draft</a> and confirm that the issue has not been addressed already.  If the issue has not been addressed, please describe it on the <a href="http://lists.w3.org/Archives/Public/public-geolocation/">public mailing list</a>.</p>
+<p>This is the First Public Working draft of this specification. <b>It should not be considered stable.</b>  When providing feedback, please first refer to the <a href="https://w3c.github.io/deviceorientation/">Editor's Draft</a> and confirm that the issue has not been addressed already.  If the issue has not been addressed, please describe it on the <a href="http://lists.w3.org/Archives/Public/public-device-apis/">public mailing list</a>.</p>
 
   <p> This document was produced by a group operating under the <a
    href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>. W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/43696/status" rel="disclosure">public list of any patent disclosures</a>


### PR DESCRIPTION
Update some spec metadata for now. IMHO we should move the spec to Bikeshed/ReSpec before publishing a new WD, since that would make publication easier.

There are 29 errors (and 5 warnings) in the Pubrules checker now: https://www.w3.org/pubrules/?url=https%3A%2F%2Fw3c.github.io%2Fdeviceorientation%2F&profile=WD-Echidna&validation=simple-validation&noRecTrack=false&informativeOnly=false&echidnaReady=true&patentPolicy=pp2004