### PR TITLE
Remove '?' from dictionary members of DeviceMotionEventInit

### DIFF
--- a/index.html
+++ b/index.html
@@ -605,9 +605,9 @@ cite this document as other than work in progress.</p>
     };
 
     dictionary DeviceMotionEventInit : EventInit {
-      DeviceAccelerationInit? acceleration;
-      DeviceAccelerationInit? accelerationIncludingGravity;
-      DeviceRotationRateInit? rotationRate;
+      DeviceAccelerationInit acceleration;
+      DeviceAccelerationInit accelerationIncludingGravity;
+      DeviceRotationRateInit rotationRate;
       double interval = 0;
     };
   </pre>


### PR DESCRIPTION
It is invalid for a dictionary member that resolves to a nullable type
to be marked with '?'. This change is effectively a no-op because these
fields remain nullable.

Resolves #54.