### PR TITLE
Reference the "use cases" section by the right number

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,7 +350,7 @@ cite this document as other than work in progress.</p>
   <p>This specification is limited to providing DOM events for retrieving
   information describing the physical orientation and motion of the hosting
   device. The intended purpose of this API is to enable simple use cases such
-  as those in <a href="#usecases">Section 5.2</a>.
+  as those in <a href="#use-cases">Section 6.1</a>.
 
   The scope of this specification does not include providing utilities to
   manipulate this data, such as transformation libraries. Nor does it include


### PR DESCRIPTION
There is no section 5.2, and use cases are listed in 6.1. Update the
reference accordingly after commits 8380389 and 1323549 (both titled "Update
spec-source-orientation.html").