### PR TITLE
Restrict all interfaces to secure contexts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -244,7 +244,7 @@ User agents must also provide an event handler IDL attribute [[!HTML]] named {{W
 
 <pre class="idl">
 partial interface Window {
-    attribute EventHandler ondeviceorientationabsolute;
+    [SecureContext] attribute EventHandler ondeviceorientationabsolute;
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -158,7 +158,7 @@ partial interface Window {
     attribute EventHandler ondeviceorientation;
 };
 
-[Constructor(DOMString type, optional DeviceOrientationEventInit eventInitDict), Exposed=Window]
+[Constructor(DOMString type, optional DeviceOrientationEventInit eventInitDict), Exposed=Window, SecureContext]
 interface DeviceOrientationEvent : Event {
     readonly attribute double? alpha;
     readonly attribute double? beta;
@@ -277,19 +277,21 @@ partial interface Window {
     attribute EventHandler ondevicemotion;
 };
 
+[SecureContext]
 interface DeviceMotionEventAcceleration {
     readonly attribute double? x;
     readonly attribute double? y;
     readonly attribute double? z;
 };
 
+[SecureContext]
 interface DeviceMotionEventRotationRate {
     readonly attribute double? alpha;
     readonly attribute double? beta;
     readonly attribute double? gamma;
 };
 
-[Constructor(DOMString type, optional DeviceMotionEventInit eventInitDict), Exposed=Window]
+[Constructor(DOMString type, optional DeviceMotionEventInit eventInitDict), Exposed=Window, SecureContext]
 interface DeviceMotionEvent : Event {
     readonly attribute DeviceMotionEventAcceleration? acceleration;
     readonly attribute DeviceMotionEventAcceleration? accelerationIncludingGravity;

--- a/index.bs
+++ b/index.bs
@@ -155,7 +155,7 @@ User agents must also provide an event handler IDL attribute [[!HTML]] named {{W
 
 <pre class="idl">
 partial interface Window {
-    attribute EventHandler ondeviceorientation;
+    [SecureContext] attribute EventHandler ondeviceorientation;
 };
 
 [Constructor(DOMString type, optional DeviceOrientationEventInit eventInitDict), Exposed=Window, SecureContext]
@@ -274,7 +274,7 @@ User agents must also provide an event handler IDL attribute [[!HTML] named {{Wi
 
 <pre class="idl">
 partial interface Window {
-    attribute EventHandler ondevicemotion;
+    [SecureContext] attribute EventHandler ondevicemotion;
 };
 
 [SecureContext]


### PR DESCRIPTION
As the next step towards fully removing `DeviceOrientationEvent` and `DeviceMotionEvent` in non-secure browsing contexts (which is tracked by #47), this change marks all interfaces with the `[SecureContext]` extended attribute, but leaves the `ondeviceorientation` or `ondevicemotion` attributes on `window` available in non-secure contexts for now.

Based on analysis from [HTTPArchive](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/5yqfAXibz1I), it is expected that when user agents implement this change, the risk of breaking existing web applications is virtually negligible.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/engedy/deviceorientation/pull/65.html" title="Last updated on Feb 27, 2019, 9:26 AM UTC (978b40a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/65/e1f5bb0...engedy:978b40a.html" title="Last updated on Feb 27, 2019, 9:26 AM UTC (978b40a)">Diff</a>