### PR TITLE
Remove trailing comma from the PermissionState enum.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -179,7 +179,7 @@ dictionary DeviceOrientationEventInit : EventInit {
 
 enum PermissionState {
     "granted",
-    "denied",
+    "denied"
 };
 </pre>
 

--- a/index.html
+++ b/index.html
@@ -1221,7 +1221,6 @@ Possible extra rowspan handling
   </style>
   <meta content="Bikeshed version 4d208866a95a1121fceca549a36bfb09c5bf1705" name="generator">
   <link href="http://www.w3.org/TR/orientation-event/" rel="canonical">
-  <meta content="fd6286e92e5446ce694c62a8ae86e761fcf497ef" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1468,7 +1467,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">DeviceOrientation Event Specification</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-04-03">3 April 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-04-05">5 April 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1669,7 +1668,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 
 <c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-permissionstate"><code><c- g>PermissionState</c-></code></dfn> {
     <dfn class="idl-code" data-dfn-for="PermissionState" data-dfn-type="enum-value" data-export id="dom-permissionstate-granted"><code><c- s>"granted"</c-></code><a class="self-link" href="#dom-permissionstate-granted"></a></dfn>,
-    <dfn class="idl-code" data-dfn-for="PermissionState" data-dfn-type="enum-value" data-export id="dom-permissionstate-denied"><code><c- s>"denied"</c-></code><a class="self-link" href="#dom-permissionstate-denied"></a></dfn>,
+    <dfn class="idl-code" data-dfn-for="PermissionState" data-dfn-type="enum-value" data-export id="dom-permissionstate-denied"><code><c- s>"denied"</c-></code><a class="self-link" href="#dom-permissionstate-denied"></a></dfn>
 };
 </pre>
    <p>The <code class="idl"><a data-link-type="idl" href="#dom-deviceorientationevent-alpha" id="ref-for-dom-deviceorientationevent-alpha②">alpha</a></code> attribute must return the value it was initialized to. When the object is created, this attribute must be initialized to null.</p>
@@ -2416,7 +2415,7 @@ for the application to ask for <a data-link-type="dfn" href="#permission" id="re
 
 <c- b>enum</c-> <a href="#enumdef-permissionstate"><code><c- g>PermissionState</c-></code></a> {
     <a href="#dom-permissionstate-granted"><code><c- s>"granted"</c-></code></a>,
-    <a href="#dom-permissionstate-denied"><code><c- s>"denied"</c-></code></a>,
+    <a href="#dom-permissionstate-denied"><code><c- s>"denied"</c-></code></a>
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window①①"><c- g>Window</c-></a> {


### PR DESCRIPTION
Even though the WebIDL grammar does allow it, specs tend to omit it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/deviceorientation/pull/73.html" title="Last updated on Apr 5, 2019, 3:45 PM UTC (2a54ff7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/73/140e016...rakuco:2a54ff7.html" title="Last updated on Apr 5, 2019, 3:45 PM UTC (2a54ff7)">Diff</a>