### PR TITLE
Add explicit [Exposed]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -327,14 +327,14 @@ partial interface Window {
     [SecureContext] attribute EventHandler ondevicemotion;
 };
 
-[SecureContext]
+[Exposed=Window, SecureContext]
 interface DeviceMotionEventAcceleration {
     readonly attribute double? x;
     readonly attribute double? y;
     readonly attribute double? z;
 };
 
-[SecureContext]
+[Exposed=Window, SecureContext]
 interface DeviceMotionEventRotationRate {
     readonly attribute double? alpha;
     readonly attribute double? beta;


### PR DESCRIPTION
Required after heycam/webidl#423. (Found from web-platform-tests/wpt#18382)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/deviceorientation/pull/79.html" title="Last updated on Aug 23, 2019, 2:44 AM UTC (174311d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/79/56e9465...saschanaz:174311d.html" title="Last updated on Aug 23, 2019, 2:44 AM UTC (174311d)">Diff</a>