### PR TITLE
Drop duplicate PermissionState definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -177,11 +177,6 @@ dictionary DeviceOrientationEventInit : EventInit {
     double? gamma = null;
     boolean absolute = false;
 };
-
-enum PermissionState {
-    "granted",
-    "denied",
-};
 </pre>
 
 The {{DeviceOrientationEvent/alpha}} attribute must return the value it was initialized to. When the object is created, this attribute must be initialized to null.


### PR DESCRIPTION
Fixes https://github.com/w3c/deviceorientation/issues/82.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/deviceorientation/pull/88.html" title="Last updated on Feb 23, 2021, 2:53 AM UTC (1e5d7a1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/88/b95751e...foolip:1e5d7a1.html" title="Last updated on Feb 23, 2021, 2:53 AM UTC (1e5d7a1)">Diff</a>