### PR TITLE
Convert Acceleration/RotationRate interfaces to dictionaries

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -328,18 +328,16 @@ partial interface Window {
     [SecureContext] attribute EventHandler ondevicemotion;
 };
 
-[Exposed=Window, SecureContext]
-interface DeviceMotionEventAcceleration {
-    readonly attribute double? x;
-    readonly attribute double? y;
-    readonly attribute double? z;
+dictionary DeviceMotionEventAcceleration {
+    double? x = null;
+    double? y = null;
+    double? z = null;
 };
 
-[Exposed=Window, SecureContext]
-interface DeviceMotionEventRotationRate {
-    readonly attribute double? alpha;
-    readonly attribute double? beta;
-    readonly attribute double? gamma;
+dictionary DeviceMotionEventRotationRate {
+    double? alpha = null;
+    double? beta = null;
+    double? gamma = null;
 };
 
 [Exposed=Window, SecureContext]
@@ -353,22 +351,10 @@ interface DeviceMotionEvent : Event {
     static Promise&lt;PermissionState> requestPermission();
 };
 
-dictionary DeviceMotionEventAccelerationInit {
-    double? x = null;
-    double? y = null;
-    double? z = null;
-};
-
-dictionary DeviceMotionEventRotationRateInit {
-    double? alpha = null;
-    double? beta = null;
-    double? gamma = null;
-};
-
 dictionary DeviceMotionEventInit : EventInit {
-    DeviceMotionEventAccelerationInit acceleration;
-    DeviceMotionEventAccelerationInit accelerationIncludingGravity;
-    DeviceMotionEventRotationRateInit rotationRate;
+    DeviceMotionEventAcceleration acceleration;
+    DeviceMotionEventAcceleration accelerationIncludingGravity;
+    DeviceMotionEventRotationRate rotationRate;
     double interval = 0;
 };
 </pre>


### PR DESCRIPTION
Fixes #89


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/deviceorientation/pull/90.html" title="Last updated on Nov 16, 2020, 6:07 PM UTC (8afe268)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/90/b95751e...saschanaz:8afe268.html" title="Last updated on Nov 16, 2020, 6:07 PM UTC (8afe268)">Diff</a>