### PR TITLE
Add a note explaining how the coordinate system differs from the CSS one.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -243,7 +243,11 @@ For a mobile device such as a phone or tablet, the device coordinate frame is de
 
 The transformation from the Earth coordinate frame to the device coordinate frame must use the following system of rotations.
 
-Rotations must use the right-hand convention, such that positive rotation around an axis is clockwise when viewed along the positive direction of the axis. Starting with the two frames aligned, the rotations are applied in the following order:
+Rotations must use the right-hand convention, such that positive rotation around an axis is clockwise when viewed along the positive direction of the axis.
+
+Note: the coordinate system used by this specification differs from [[css-transforms-2#transform-rendering]], where the y axis is positive to the bottom and rotations follow the left-hand convention. Additionally, {{DOMMatrix/rotateSelf()}} and {{DOMMatrixReadOnly/rotate()}}, specified in [[GEOMETRY-1]], apply rotations in an Z - Y' - X'' order, which differs from the order specified here.
+
+Starting with the two frames aligned, the rotations are applied in the following order:
 
 <ol id="rotations">
 <li>


### PR DESCRIPTION
The Device Orientation spec uses a right-handed system with Y being positive
upwards, while the CSS coordinate system uses a left-handed system with Y
being positive downwards. Additionally, DOMMatrixReadOnly.rotate() and its
DOMMatrix.rotateSelf() counterpart both apply rotations in a Z-Y'-X'' order
that differs from the Z-X'-Y'' order here and can also lead to confusion and
wrong rotations.

Chromium's own DevTools code for overriding Device Orientation values has
had multiple issues with this over the years, the latest one being
https://crbug.com/1137281, so it is probably a good idea to make it more
explicit to others.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/deviceorientation/pull/92.html" title="Last updated on Dec 2, 2020, 2:19 PM UTC (d85373b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/92/b95751e...rakuco:d85373b.html" title="Last updated on Dec 2, 2020, 2:19 PM UTC (d85373b)">Diff</a>