### PR TITLE
Fix reference to HTML spec in devicemotion event description.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -325,7 +325,7 @@ The default action of this event should be for the user agent to present the use
 
 User agents implementing this specification must provide a new DOM event, named <dfn id="def-devicemotion"><code>devicemotion</code></dfn>. The corresponding event must be of type {{DeviceMotionEvent}} and must fire on the {{window!!attribute}} object. Registration for, and firing of the [=devicemotion=] event must follow the usual behavior of DOM4 Events, [[!DOM4]].
 
-User agents must also provide an event handler IDL attribute [[!HTML] named {{Window/ondevicemotion}} on the {{window!!attribute}} object. The type of the corresponding [=event handler event type=] must be [=devicemotion=].
+User agents must also provide an event handler IDL attribute [[!HTML]] named {{Window/ondevicemotion}} on the {{window!!attribute}} object. The type of the corresponding [=event handler event type=] must be [=devicemotion=].
 
 <pre class="idl">
 partial interface Window {


### PR DESCRIPTION
Add a missing `]` in that was preventing Bikeshed from creating a proper
reference link in the spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/deviceorientation/pull/93.html" title="Last updated on Jun 1, 2021, 10:29 AM UTC (f2bbd3c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/93/8221924...rakuco:f2bbd3c.html" title="Last updated on Jun 1, 2021, 10:29 AM UTC (f2bbd3c)">Diff</a>