### PR TITLE
Fix example 9

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -134,7 +134,7 @@ A device in free-fall, with the screen horizontal and upmost, has an {{DeviceMot
 A device is mounted in a vehicle, with the screen in a vertical plane, the top uppermost and facing the rear of the vehicle. The vehicle is travelling at speed v around a right-hand bend of radius r. The device records a positive x component for both {{DeviceMotionEvent/acceleration}} and {{DeviceMotionEvent/accelerationIncludingGravity}}. The device also records a negative value for {{DeviceMotionEvent/rotationRate!!attribute}}.{{DeviceMotionEventRotationRate/gamma}}:
 <pre class="lang-json">
 {acceleration: {x: v^2/r, y: 0, z: 0},
- accelerationIncludingGravity: {x: v^2/r, y: 0, z: 9.8},
+ accelerationIncludingGravity: {x: v^2/r, y: 9.8, z: 0},
  rotationRate: {alpha: 0, beta: 0, gamma: -v/r*180/pi} };
 </pre>
 </div>


### PR DESCRIPTION
When  the phone is upright, gravity adds 9.8 to the y-axis, so `accelerationIncludingGravity` is `{ x: v^2/r, y: 9.8, z: 0 }` (not 9.8 on z-axis as currently)

closes #98


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chaals/deviceorientation/pull/99.html" title="Last updated on Jul 8, 2021, 3:55 PM UTC (1f9fffa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/99/e5ee004...chaals:1f9fffa.html" title="Last updated on Jul 8, 2021, 3:55 PM UTC (1f9fffa)">Diff</a>