### PR TITLE
Use Permission Spec's PermissionState

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -178,10 +178,6 @@ dictionary DeviceOrientationEventInit : EventInit {
     boolean absolute = false;
 };
 
-enum PermissionState {
-    "granted",
-    "denied",
-};
 </pre>
 
 The {{DeviceOrientationEvent/alpha}} attribute must return the value it was initialized to. When the object is created, this attribute must be initialized to null.


### PR DESCRIPTION
Avoid duplicate definition of PermissionState, which is "owned" by Permission spec...

We should eventually go over and do proper integration with the Permission spec. This is a start.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/pull/101.html" title="Last updated on Oct 13, 2021, 6:16 AM UTC (6cbfd51)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/101/9d26c4a...6cbfd51.html" title="Last updated on Oct 13, 2021, 6:16 AM UTC (6cbfd51)">Diff</a>