### PR TITLE
Align with DOM phrasing on firing events

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -41,7 +41,7 @@ User agents may impose implementation-specific limits on otherwise unconstrained
 
 Implementations that use ECMAScript to implement the APIs defined in this specification must implement them in a manner consistent with the ECMAScript Bindings defined in the Web IDL specification, as this specification uses that specification's terminology. [[!WEBIDL]]
 
-The events introduced by this specification implement the Event interface defined in the DOM4 Specification, [[!DOM4]]. Implementations must therefore support this specification.
+The events introduced by this specification implement the Event interface defined in the DOM Specification, [[!DOM]]. Implementations must therefore support this specification.
 
 
 
@@ -52,16 +52,16 @@ Introduction {#introduction}
 
 This specification provides several new DOM events for obtaining information about the physical orientation and movement of the hosting device. The information provided by the events is not raw sensor data, but rather high-level data which is agnostic to the underlying source of information. Common sources of information include gyroscopes, compasses and accelerometers.
 
-The first DOM event provided by the specification, [=deviceorientation=], supplies the physical orientation of the device, expressed as a series of rotations from a local coordinate frame.
+The first DOM event provided by the specification, {{deviceorientation}}, supplies the physical orientation of the device, expressed as a series of rotations from a local coordinate frame.
 
-The second DOM event provided by this specification, [=devicemotion=], supplies the acceleration of the device, expressed in Cartesian coordinates in a coordinate frame defined in the device. It also supplies the rotation rate of the device about a local coordinate frame. Where practically possible, the event should provide the acceleration of the device's center of mass.
+The second DOM event provided by this specification, {{devicemotion}}, supplies the acceleration of the device, expressed in Cartesian coordinates in a coordinate frame defined in the device. It also supplies the rotation rate of the device about a local coordinate frame. Where practically possible, the event should provide the acceleration of the device's center of mass.
 
-Finally, the specification provides a [=compassneedscalibration=] DOM event, which is used to inform Web sites that a compass being used to provide data for one of the above events is in need of calibration.
+Finally, the specification provides a {{compassneedscalibration}} DOM event, which is used to inform Web sites that a compass being used to provide data for one of the above events is in need of calibration.
 
 The following code extracts illustrate basic use of the events.
 
 <div class="example">
-Registering to receive [=deviceorientation=] events:
+Registering to receive {{deviceorientation}} events:
 <pre class="lang-js">
 window.addEventListener("deviceorientation", function(event) {
     // process event.alpha, event.beta and event.gamma
@@ -103,7 +103,7 @@ window.addEventListener("compassneedscalibration", function(event) {
 </div>
 
 <div class="example">
-Registering to receive [=devicemotion=] events:
+Registering to receive {{devicemotion}} events:
 <pre class="lang-js">
 window.addEventListener("devicemotion", function(event) {
     // Process event.acceleration, event.accelerationIncludingGravity,
@@ -151,9 +151,9 @@ Description {#description}
 
 <h3 id="deviceorientation">deviceorientation Event</h3>
 
-User agents implementing this specification must provide a new DOM event, named <dfn id="def-deviceorientation"><code>deviceorientation</code></dfn>. The corresponding event must be of type {{DeviceOrientationEvent}} and must fire on the {{window!!attribute}} object. Registration for, and firing of the [=deviceorientation=] event must follow the usual behavior of DOM4 Events, [[!DOM4]].
+User agents implementing this specification must provide a new DOM event, named <dfn event for=Window id="def-deviceorientation"><code>deviceorientation</code></dfn>.
 
-User agents must also provide an event handler IDL attribute [[!HTML]] named {{Window/ondeviceorientation}} on the {{window!!attribute}} object. The type of the corresponding [=event handler event type=] must be [=deviceorientation=].
+User agents must also provide an event handler IDL attribute [[!HTML]] named {{Window/ondeviceorientation}} on the {{window!!attribute}} object. The type of the corresponding [=event handler event type=] must be {{deviceorientation}}.
 
 <pre class="idl">
 partial interface Window {
@@ -225,7 +225,7 @@ The static {{DeviceOrientationEvent/requestPermission()}} operation, when invoke
  <li><p>Return <var>promise</var>.
 </ol>
 
-The event should fire whenever a significant change in orientation occurs. The definition of a significant change in this context is left to the implementation, though a maximum threshold for change of one degree is recommended. Implementations may also fire the event if they have reason to believe that the page does not have sufficiently fresh data.
+Whenever a significant change in orientation occurs, the User Agent must [=fire an event=] named {{deviceorientation}} using {{DeviceOrientationEvent}} on the {{window!!attribute}} object. The definition of a significant change in this context is left to the implementation, though a maximum threshold for change of one degree is recommended. Implementations may also fire the event if they have reason to believe that the page does not have sufficiently fresh data.
 
 The {{DeviceOrientationEvent/alpha}}, {{DeviceOrientationEvent/beta}} and {{DeviceOrientationEvent/gamma}} attributes of the event must specify the orientation of the device in terms of the transformation from a coordinate frame fixed on the Earth to a coordinate frame fixed in the device. The {{DeviceOrientationEvent/alpha}}, {{DeviceOrientationEvent/beta}} and {{DeviceOrientationEvent/gamma}} attributes must be expressed in degrees and must not be more precise than 0.1 degrees. The coordinate frames must be oriented as described below.
 
@@ -279,19 +279,19 @@ Starting with the two frames aligned, the rotations are applied in the following
 
 Thus the angles {{DeviceOrientationEvent/alpha}}, {{DeviceOrientationEvent/beta}} and {{DeviceOrientationEvent/gamma}} form a set of intrinsic Tait-Bryan angles of type Z - X' - Y''. [[EULERANGLES]] Note that this choice of angles follows mathematical convention, but means that alpha is in the opposite sense to a compass heading. It also means that the angles do not match the roll-pitch-yaw convention used in vehicle dynamics.
 
-The [=deviceorientation=] event tries to provide relative values for the three angles (relative to some arbitrary orientation), based on just the accelerometer and the gyroscope. The implementation can still decide to provide absolute orientation if relative is not available or the resulting data is more accurate. In either case, the {{DeviceOrientationEvent/absolute}} property must be set accordingly to reflect the choice.
+The {{deviceorientation}} event tries to provide relative values for the three angles (relative to some arbitrary orientation), based on just the accelerometer and the gyroscope. The implementation can still decide to provide absolute orientation if relative is not available or the resulting data is more accurate. In either case, the {{DeviceOrientationEvent/absolute}} property must be set accordingly to reflect the choice.
 
 Implementations that are unable to provide all three angles must set the values of the unknown angles to null. If any angles are provided, the {{DeviceOrientationEvent/absolute}} property must be set appropriately. If an implementation can never provide orientation information, the event should be fired with the {{DeviceOrientationEvent/alpha}}, {{DeviceOrientationEvent/beta}} and {{DeviceOrientationEvent/gamma}} attributes set to null.
 
 <h3 id="deviceorientationabsolute">deviceorientationabsolute Event</h3>
 
 <div class="issue">
-The [=deviceorientationabsolute=] event and its {{Window/ondeviceorientationabsolute}} event handler IDL attribute have <a href="https://wpt.fyi/results/orientation-event/ondeviceorientationabsolute.https.html">limited implementation experience</a>.
+The {{deviceorientationabsolute}} event and its {{Window/ondeviceorientationabsolute}} event handler IDL attribute have <a href="https://wpt.fyi/results/orientation-event/ondeviceorientationabsolute.https.html">limited implementation experience</a>.
 </div>
 
-User agents implementing this specification must provide a new DOM event, named <dfn id="def-deviceorientationabsolute"><code>deviceorientationabsolute</code></dfn>. The corresponding event must be of type {{DeviceOrientationEvent}} and must fire on the {{window!!attribute}} object. Registration for, and firing of the [=deviceorientationabsolute=] event must follow the usual behavior of DOM4 Events, [[!DOM4]].
+User agents implementing this specification must [=fire an event=] named <dfn event for="Window" id="def-deviceorientationabsolute"><code>deviceorientationabsolute</code></dfn> using {{DeviceOrientationEvent}} on the {{window!!attribute}} object whenever a significant change in orientation occurs.
 
-User agents must also provide an event handler IDL attribute [[!HTML]] named {{Window/ondeviceorientationabsolute}} on the {{window!!attribute}} object. The type of the corresponding [=event handler event type=] must be [=deviceorientationabsolute=].
+User agents must also provide an event handler IDL attribute [[!HTML]] named {{Window/ondeviceorientationabsolute}} on the {{window!!attribute}} object. The type of the corresponding [=event handler event type=] must be {{deviceorientationabsolute}}.
 
 <pre class="idl">
 partial interface Window {
@@ -299,17 +299,17 @@ partial interface Window {
 };
 </pre>
 
-The [=deviceorientationabsolute=] event is completely analogous to the [=deviceorientation=] event, except additional sensors like the magnetometer can be used to provide an absolute orientation. The {{DeviceOrientationEvent/absolute}} property must be set to true. If an implementation can never provide absolute orientation information, the event should be fired with the {{DeviceOrientationEvent/alpha}}, {{DeviceOrientationEvent/beta}} and {{DeviceOrientationEvent/gamma}} attributes set to null.
+The {{deviceorientationabsolute}} event is completely analogous to the {{deviceorientation}} event, except additional sensors like the magnetometer can be used to provide an absolute orientation. The {{DeviceOrientationEvent/absolute}} property must be set to true. If an implementation can never provide absolute orientation information, the event should be fired with the {{DeviceOrientationEvent/alpha}}, {{DeviceOrientationEvent/beta}} and {{DeviceOrientationEvent/gamma}} attributes set to null.
 
 <h3 id="compassneedscalibration">compassneedscalibration Event</h3>
 
 <div class="issue">
-The [=compassneedscalibration=] event and its {{Window/oncompassneedscalibration}} event handler IDL attribute have <a href="https://github.com/w3c/deviceorientation/issues/38">limited implementation experience</a>.
+The {{compassneedscalibration}} event and its {{Window/oncompassneedscalibration}} event handler IDL attribute have <a href="https://github.com/w3c/deviceorientation/issues/38">limited implementation experience</a>.
 </div>
 
-User agents implementing this specification must provide a new DOM event, named <dfn id="def-compassneedscalibration"><code>compassneedscalibration</code></dfn> that uses the Event interface defined in the DOM4 Events specification [[!DOM4]]. This event must fire on the {{window!!attribute}} object. Registration for, and firing of the [=compassneedscalibration=] event must follow the usual behavior of DOM4 Events [[!DOM4]].
+User agents implementing this specification must provide a new DOM event, named <dfn event for="Window" id="def-compassneedscalibration"><code>compassneedscalibration</code></dfn>.
 
-User agents must also provide an event handler IDL attribute [[!HTML]] named {{Window/oncompassneedscalibration}} on the {{window!!attribute}} object. The type of the corresponding event must be [=compassneedscalibration=].
+User agents must also provide an event handler IDL attribute [[!HTML]] named {{Window/oncompassneedscalibration}} on the {{window!!attribute}} object. The type of the corresponding event must be {{compassneedscalibration}}.
 
 <pre class="idl">
 partial interface Window {
@@ -317,15 +317,15 @@ partial interface Window {
 };
 </pre>
 
-This event must be fired when the user agent determines that a compass used to obtain orientation data is in need of calibration. Furthermore, user agents should only fire the event if calibrating the compass will increase the accuracy of the data provided by the [=deviceorientation=] event.
+User agent must [=fire an event=] named {{compassneedscalibration}} on the {{window!!attribute}} object when the user agent determines that a compass used to obtain orientation data is in need of calibration. Furthermore, user agents should only fire the event if calibrating the compass will increase the accuracy of the data provided by the {{deviceorientation}} event.
 
 The default action of this event should be for the user agent to present the user with details of how to calibrate the compass. The event must be cancelable, so that web sites can provide their own alternative calibration UI.
 
 <h3 id="devicemotion">devicemotion Event</h3>
 
-User agents implementing this specification must provide a new DOM event, named <dfn id="def-devicemotion"><code>devicemotion</code></dfn>. The corresponding event must be of type {{DeviceMotionEvent}} and must fire on the {{window!!attribute}} object. Registration for, and firing of the [=devicemotion=] event must follow the usual behavior of DOM4 Events, [[!DOM4]].
+User agents implementing this specification must [=fire an event=] named <dfn event for=Window id="def-devicemotion"><code>devicemotion</code></dfn> using {{DeviceMotionEvent}} on the {{window!!attribute}} object.
 
-User agents must also provide an event handler IDL attribute [[!HTML]] named {{Window/ondevicemotion}} on the {{window!!attribute}} object. The type of the corresponding [=event handler event type=] must be [=devicemotion=].
+User agents must also provide an event handler IDL attribute [[!HTML]] named {{Window/ondevicemotion}} on the {{window!!attribute}} object. The type of the corresponding [=event handler event type=] must be {{devicemotion}}.
 
 <pre class="idl">
 partial interface Window {


### PR DESCRIPTION
see dom.spec.whatwg.org/#firing-events-example


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/deviceorientation/pull/102.html" title="Last updated on Jun 8, 2022, 3:25 PM UTC (a94bfe8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/102/9d26c4a...dontcallmedom:a94bfe8.html" title="Last updated on Jun 8, 2022, 3:25 PM UTC (a94bfe8)">Diff</a>