### PR TITLE
Update reference to "triggered by user activation"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -213,7 +213,7 @@ The static {{DeviceOrientationEvent/requestPermission()}} operation, when invoke
    <li><p>Let <var>permission</var> be <a>permission</a> for
    <a>relevant settings object</a>'s <a for="environment settings object">origin</a>.
 
-   <li><p>If <var>permission</var> is "<code>default</code>" and the method call was not <a>triggered by user activation</a>, then reject <var>promise</var> with a
+   <li><p>If <var>permission</var> is "<code>default</code>" and <a>relevant global object</a> does not have <a>transient activation</a>, then reject <var>promise</var> with a
    {{NotAllowedError!!exception}} {{DOMException}} and abort these steps.
 
    <li><p>If <var>permission</var> is "<code>default</code>", ask the user whether sharing device orientation


### PR DESCRIPTION
This concept is now referred to as "transient activation".

Fixed #105.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/pull/106.html" title="Last updated on Jan 9, 2023, 7:08 PM UTC (3dd77f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/106/5791e0b...3dd77f0.html" title="Last updated on Jan 9, 2023, 7:08 PM UTC (3dd77f0)">Diff</a>