### PR TITLE
Remove the oncompassneedscalibration event

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -50,13 +50,11 @@ Introduction {#introduction}
 
 <em>This section is non-normative.</em>
 
-This specification provides several new DOM events for obtaining information about the physical orientation and movement of the hosting device. The information provided by the events is not raw sensor data, but rather high-level data which is agnostic to the underlying source of information. Common sources of information include gyroscopes, compasses and accelerometers.
+This specification provides two new DOM events for obtaining information about the physical orientation and movement of the hosting device. The information provided by the events is not raw sensor data, but rather high-level data which is agnostic to the underlying source of information. Common sources of information include gyroscopes, compasses and accelerometers.
 
 The first DOM event provided by the specification, {{deviceorientation}}, supplies the physical orientation of the device, expressed as a series of rotations from a local coordinate frame.
 
 The second DOM event provided by this specification, {{devicemotion}}, supplies the acceleration of the device, expressed in Cartesian coordinates in a coordinate frame defined in the device. It also supplies the rotation rate of the device about a local coordinate frame. Where practically possible, the event should provide the acceleration of the device's center of mass.
-
-Finally, the specification provides a {{compassneedscalibration}} DOM event, which is used to inform Web sites that a compass being used to provide data for one of the above events is in need of calibration.
 
 The following code extracts illustrate basic use of the events.
 
@@ -93,16 +91,6 @@ A user facing a compass heading of alpha degrees is holding the device in their 
   beta: 0,
   gamma: 90
 };
-</pre>
-</div>
-
-<div class="example">
-Showing custom UI to instruct the user to calibrate the compass:
-<pre class="lang-js">
-window.addEventListener("compassneedscalibration", function(event) {
-    alert('Your compass needs calibrating! Wave your device in a figure-eight motion');
-    event.preventDefault();
-}, true);
 </pre>
 </div>
 
@@ -305,26 +293,6 @@ partial interface Window {
 </pre>
 
 The {{deviceorientationabsolute}} event is completely analogous to the {{deviceorientation}} event, except additional sensors like the magnetometer can be used to provide an absolute orientation. The {{DeviceOrientationEvent/absolute}} property must be set to true. If an implementation can never provide absolute orientation information, the event should be fired with the {{DeviceOrientationEvent/alpha}}, {{DeviceOrientationEvent/beta}} and {{DeviceOrientationEvent/gamma}} attributes set to null.
-
-<h3 id="compassneedscalibration">compassneedscalibration Event</h3>
-
-<div class="issue">
-The {{compassneedscalibration}} event and its {{Window/oncompassneedscalibration}} event handler IDL attribute have <a href="https://github.com/w3c/deviceorientation/issues/38">limited implementation experience</a>.
-</div>
-
-User agents implementing this specification must provide a new DOM event, named <dfn event for="Window" id="def-compassneedscalibration"><code>compassneedscalibration</code></dfn>.
-
-User agents must also provide an event handler IDL attribute [[!HTML]] named {{Window/oncompassneedscalibration}} on the {{window!!attribute}} object. The type of the corresponding event must be {{compassneedscalibration}}.
-
-<pre class="idl">
-partial interface Window {
-    attribute EventHandler oncompassneedscalibration;
-};
-</pre>
-
-User agents must [=fire an event=] named {{compassneedscalibration}} on the {{window!!attribute}} object when the user agent determines that a compass used to obtain orientation data is in need of calibration. Furthermore, user agents should only fire the event if calibrating the compass will increase the accuracy of the data provided by the {{deviceorientation}} event.
-
-The default action of this event should be for the user agent to present the user with details of how to calibrate the compass. The event must be cancelable, so that web sites can provide their own alternative calibration UI.
 
 <h3 id="devicemotion">devicemotion Event</h3>
 


### PR DESCRIPTION
There are no implementations of this event.

Fixed #38.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/pull/107.html" title="Last updated on Mar 7, 2023, 12:57 AM UTC (7f1c214)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/107/7e1e1d9...7f1c214.html" title="Last updated on Mar 7, 2023, 12:57 AM UTC (7f1c214)">Diff</a>