### PR TITLE
Editorial: mark sections as non-normative

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -454,20 +454,25 @@ Use-Cases and Requirements {#use-cases-and-requirements}
 ========================================================
 
 <h3 id="use-cases">Use-Cases</h3>
+<em>This section is non-normative.</em>
 
 <h4 class="no-toc" id="controlling-a-game">Controlling a game</h4>
+<em>This section is non-normative.</em>
 
 A gaming Web application monitors the device's orientation and interprets tilting in a certain direction as a means to control an on-screen sprite.
 
 <h4 class="no-toc" id="gesture-recognition">Gesture recognition</h4>
+<em>This section is non-normative.</em>
 
 A Web application monitors the device's acceleration and applies signal processing in order to recognize certain specific gestures. For example, using a shaking gesture to clear a web form.
 
 <h4 class="no-toc" id="mapping">Mapping</h4>
+<em>This section is non-normative.</em>
 
 A mapping Web application uses the device's orientation to correctly align the map with reality.
 
 <h3 id="requirements">Requirements</h3>
+<em>This section is non-normative.</em>
 
 * The specification must provide data that describes the physical orientation in space of the device.
 * The specification must provide data that describes the motion in space of the device.
@@ -476,6 +481,7 @@ A mapping Web application uses the device's orientation to correctly align the m
 * The specification must use the existing DOM event framework.
 
 <h2 class="no-num" id="examples">A Examples</h2>
+<em>This section is non-normative.</em>
 
 <h3 id="worked-example">A.1 Calculating compass heading</h3>
 


### PR DESCRIPTION
Couple of informative sections are not explicitly marked as non-normative.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/deviceorientation/pull/108.html" title="Last updated on Apr 1, 2023, 2:56 AM UTC (2f45469)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/108/07d52cd...marcoscaceres:2f45469.html" title="Last updated on Apr 1, 2023, 2:56 AM UTC (2f45469)">Diff</a>