### PR TITLE
Update remaining reference to "triggered by user activation"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -196,7 +196,7 @@ The static {{DeviceOrientationEvent/requestPermission()}} operation, when invoke
    <li><p>Let <var>permission</var> be <a>permission</a> for
    <a>relevant settings object</a>'s <a for="environment settings object">origin</a>.
 
-   <li><p>If <var>permission</var> is "<code>default</code>" and <a>relevant global object</a> does not have <a>transient activation</a>, then reject <var>promise</var> with a
+   <li><p>If <var>permission</var> is "<code>default</code>" and the <a>relevant global object</a> does not have <a>transient activation</a>, then reject <var>promise</var> with a
    {{NotAllowedError!!exception}} {{DOMException}} and abort these steps.
 
    <li><p>If <var>permission</var> is "<code>default</code>", ask the user whether sharing device orientation
@@ -369,7 +369,7 @@ The static {{DeviceMotionEvent/requestPermission()}} operation, when invoked, mu
    <li><p>Let <var>permission</var> be <a>permission</a> for
    <a>relevant settings object</a>'s <a for="environment settings object">origin</a>.
 
-   <li><p>If <var>permission</var> is "<code>default</code>" and the method call was not <a>triggered by user activation</a>, then reject <var>promise</var> with a
+   <li><p>If <var>permission</var> is "<code>default</code>" and the <a>relevant global object</a> does not have <a>transient activation</a>, then reject <var>promise</var> with a
    {{NotAllowedError!!exception}} {{DOMException}} and abort these steps.
 
    <li><p>If <var>permission</var> is "<code>default</code>", ask the user whether sharing device motion
@@ -715,8 +715,6 @@ Lars Erik Bolstad, Dean Jackson, Claes Nilsson, George Percivall, Doug Turner, M
 urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: webappapis.html; type: dfn
         text: relevant settings object
-    urlPrefix: interaction.html; type: dfn
-        text: triggered by user activation
 </pre>
 
 <pre class="biblio">


### PR DESCRIPTION
The change in #106 only fixed one instance of "triggered by user interaction". This fixes the other.

Fixed #109.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/pull/110.html" title="Last updated on Apr 12, 2023, 6:16 PM UTC (e4067d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/110/23db732...e4067d0.html" title="Last updated on Apr 12, 2023, 6:16 PM UTC (e4067d0)">Diff</a>