### PR TITLE
editorial: Reword requirements in "Security and privacy considerations"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -22,9 +22,6 @@ Issue Tracking: DeviceOrientation Event Specification Issues Repository https://
 urlPrefix: https://compat.spec.whatwg.org/; spec: COMPATIBILITY
     type: interface
         text: orientationchange; url: event-orientationchange
-urlPrefix: https://www.w3.org/TR/page-visibility-2/; spec: PAGE-VISIBILITY
-    type: dfn
-        text: visible; url: dom-visibilitystate-visible
 </pre>
 
 Conformance requirements {#conformance-requirements}
@@ -444,9 +441,9 @@ The API defined in this specification can be used to obtain information from har
 
 In light of that, implementations may consider permissions or visual indicators to signify the use of sensors by the web page. Furthermore, to minimize privacy risks, the chance of fingerprinting and other attacks the implementations must:
 
-* fire events only when [=active document=] is [=visible=],
-* fire events only on the [=top-level browsing context=] and same-origin [=nested browsing contexts=],
-* fire events only on secure browsing contexts [[!SECURE-CONTEXTS]],
+* fire events only when a [=/navigable=]'s [=navigable/active document=]'s [=visibility state=] is "<code>visible</code>",
+* fire events only on the [=/top-level traversable=]'s [=navigable/active window=] and [=child navigables=]' [=navigable/active windows=] whose [=relevant settings object=]'s [=environment settings object/origin=] is [=same origin=] with the [=/top-level traversable=]'s [=navigable/active window=]'s [=relevant settings object=]'s [=environment settings object/origin=].
+* fire events on a [=/navigable=]'s [=navigable/active windows=] only when its [=relevant settings object=] is a [=secure context=],
 * limit precision of attribute values as described in the previous sections.
 
 Additionally, implementing these items may also have a beneficial impact on the battery life of mobile devices.


### PR DESCRIPTION
Use more modern spec terminology in the list of requirements for firing
device orientation and motion events:

- Use navigables and concepts defined for navigables when dealing with
  windows and documents.
- Stop referring to the PAGE-VISIBILITY spec, as it was merged into HTML a
  few years ago. Use a document's visibility state instead.
- Use more precise terms when laying out the same-origin requirements
  between the top-level traversable and its child navigables. The new
  paragraph is a mouthful, but also more precise.
- Instead of referring to the SECURE-CONTEXTS spec, use HTML's definition of
  "secure context".

This change should not cause any behavioral or user-detectable changes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/pull/114.html" title="Last updated on Oct 30, 2023, 3:06 PM UTC (231b78d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/114/e468d70...231b78d.html" title="Last updated on Oct 30, 2023, 3:06 PM UTC (231b78d)">Diff</a>