### PR TITLE
Add Security and Privacy Self-Review Questionnaire

### DIFF
--- a/security-privacy-self-assessment.md
+++ b/security-privacy-self-assessment.md
@@ -53,7 +53,7 @@ No.
 
 ### 2.11 Do features in this specification allow an origin some measure of control over a user agent’s native UI?
 
-No.
+The specification includes a method to request the user agent display a permission prompt, the contents of which are implementation-defined.
 
 ### 2.12 What temporary identifiers do the features in this specification create or expose to the web?
 

--- a/security-privacy-self-assessment.md
+++ b/security-privacy-self-assessment.md
@@ -69,7 +69,7 @@ No difference to the browser's 'normal' state.
 
 ### 2.15 Does this specification have both "Security Considerations" and "Privacy Considerations" sections?
 
-Combined together.
+Yes, combined together.
 
 ### 2.16 Do features in your specification enable origins to downgrade default security protections?
 

--- a/security-privacy-self-assessment.md
+++ b/security-privacy-self-assessment.md
@@ -19,7 +19,7 @@ The data precision is normatively limited to resist fingerprinting (see 2.6).
 
 ### 2.3 How do the features in your specification deal with personal information, personally-identifiable information (PII), or information derived from them?
 
-This specification does not deal with PII directly. The specification requires users to give express permission for the user agent to provide device motion and/or orientation data.
+This specification does not deal with PII directly, however identifiable information such as gait can be determined from monitoring sensor readings over time. The specification requires users to give express permission for the user agent to provide device motion and/or orientation data.
 
 ### 2.4 How do the features in your specification deal with sensitive information?
 

--- a/security-privacy-self-assessment.md
+++ b/security-privacy-self-assessment.md
@@ -13,9 +13,9 @@ Information about the physical orientation and movement of the hosting device. S
 
 ### 2.2 Do features in your specification expose the minimum amount of information necessary to enable their intended uses?
 
-This specification expresses a device’s physical orientation as a series of rotations relative to an implementation-defined reference coordinate frame in order to realize its use cases.
+This specification allows developers to request access to only the set of sensor data necessary, either a "device motion" event for motion-controlled applications or a "device orientation" event for orientation control. Since absolute orientation exposes more information, a "relative orientation" option is available if the compass heading is unnecessary.
 
-The rate at which this information is delivered via events is implementation-defined.
+The data precision is normatively limited to resist fingerprinting (see 2.6).
 
 ### 2.3 How do the features in your specification deal with personal information, personally-identifiable information (PII), or information derived from them?
 

--- a/security-privacy-self-assessment.md
+++ b/security-privacy-self-assessment.md
@@ -19,7 +19,7 @@ The data precision is normatively limited to resist fingerprinting (see 2.6).
 
 ### 2.3 How do the features in your specification deal with personal information, personally-identifiable information (PII), or information derived from them?
 
-This specification does not deal with PII directly, however identifiable information such as gait can be determined from monitoring sensor readings over time. The specification requires users to give express permission for the user agent to provide device motion and/or orientation data.
+This specification does not deal with PII directly, however identifiable information such as gait can be determined from monitoring sensor readings over time. The specification requires users to give express permission for the user agent to provide device motion and/or orientation data. Furthermore, all interfaces are restricted to secure contexts to protect against both active and passive network attackers.
 
 ### 2.4 How do the features in your specification deal with sensitive information?
 

--- a/security-privacy-self-assessment.md
+++ b/security-privacy-self-assessment.md
@@ -31,7 +31,7 @@ This specification defines new [permissions](https://www.w3.org/TR/orientation-e
 
 ### 2.6 Do the features in your specification expose information about the underlying platform to origins?
 
-Minor manufacturing imperfections and differences unique to the underlying platform and the sensor hardware in the hosting device can be detected through readings over time.
+Minor manufacturing imperfections and differences unique to the underlying platform and the sensor hardware in the hosting device might be detected through readings over time.
 
 The specification mitigates this type of passive fingerprinting by normatively limiting rotation and acceleration precision to at most 0.1 degrees, 0.1 degrees per second or 0.1 meters per second squared as appropriate. More context is available in a [paper](https://github.com/JensenPaul/sensor-fingerprint-mitigation).
 

--- a/security-privacy-self-assessment.md
+++ b/security-privacy-self-assessment.md
@@ -33,7 +33,7 @@ This specification defines new [permissions](https://www.w3.org/TR/orientation-e
 
 Minor manufacturing imperfections and differences unique to the underlying platform and the sensor hardware in the hosting device can be detected through readings over time.
 
-The specification mitigates this type of passive fingerprinting by normatively limiting rotation and acceleration precision to at most 0.1 degrees, 0.1 degrees per second, 0.1 meters per second squared. More context is available in a [paper](https://github.com/JensenPaul/sensor-fingerprint-mitigation).
+The specification mitigates this type of passive fingerprinting by normatively limiting rotation and acceleration precision to at most 0.1 degrees, 0.1 degrees per second or 0.1 meters per second squared as appropriate. More context is available in a [paper](https://github.com/JensenPaul/sensor-fingerprint-mitigation).
 
 ### 2.7 Does this specification allow an origin to send data to the underlying platform?
 

--- a/security-privacy-self-assessment.md
+++ b/security-privacy-self-assessment.md
@@ -61,7 +61,7 @@ None.
 
 ### 2.13 How does this specification distinguish between behavior in first-party and third-party contexts?
 
-No.
+It does not.
 
 ### 2.14 How do the features in this specification work in the context of a browser’s Private Browsing or Incognito mode?
 

--- a/security-privacy-self-assessment.md
+++ b/security-privacy-self-assessment.md
@@ -1,0 +1,84 @@
+# Security and Privacy Self-Review Questionnaire for DeviceOrientation Event
+
+[Self-Review Questionnaire](https://www.w3.org/TR/security-privacy-questionnaire/)
+responses for the [DeviceOrientation Event](https://www.w3.org/TR/orientation-event/) specification.
+
+Related Self-Review Questionnaires:
+- [Generic Sensor API](https://github.com/w3c/sensors/blob/main/security-questionnaire.md)
+- [Orientation Sensor API](https://github.com/w3c/orientation-sensor/blob/main/security-questionnaire.md)
+
+### 2.1 What information might this feature expose to Web sites or other parties, and for what purposes is that exposure necessary?
+
+Information about the physical orientation and movement of the hosting device. See [use cases](https://www.w3.org/TR/orientation-event/#use-cases).
+
+### 2.2 Do features in your specification expose the minimum amount of information necessary to enable their intended uses?
+
+This specification expresses a device’s physical orientation as a series of rotations relative to an implementation-defined reference coordinate frame in order to realize its use cases.
+
+The rate at which this information is delivered via events is implementation-defined.
+
+### 2.3 How do the features in your specification deal with personal information, personally-identifiable information (PII), or information derived from them?
+
+This specification does not deal with PII directly. The specification requires users to give express permission for the user agent to provide device motion and/or orientation data.
+
+### 2.4 How do the features in your specification deal with sensitive information?
+
+See 2.3.
+
+### 2.5 Do the features in your specification introduce new state for an origin that persists across browsing sessions?
+
+No.
+
+### 2.6 Do the features in your specification expose information about the underlying platform to origins?
+
+Minor manufacturing imperfections and differences unique to the underlying platform and the sensor hardware in the hosting device can be detected through readings over time.
+
+The specification mitigates this type of passive fingerprinting by normatively limiting rotation and acceleration precision to at most 0.1 degrees, 0.1 degrees per second, 0.1 meters per second squared. More context is available in a [paper](https://github.com/JensenPaul/sensor-fingerprint-mitigation).
+
+### 2.7 Does this specification allow an origin to send data to the underlying platform?
+
+No.
+
+### 2.8 Do features in this specification enable access to device sensors?
+
+Yes. See 2.1 and 2.2.
+
+### 2.9 Do features in this specification enable new script execution/loading mechanisms?
+
+No.
+
+### 2.10 Do features in this specification allow an origin to access other devices?
+
+No.
+
+### 2.11 Do features in this specification allow an origin some measure of control over a user agent’s native UI?
+
+No.
+
+### 2.12 What temporary identifiers do the features in this specification create or expose to the web?
+
+None.
+
+### 2.13 How does this specification distinguish between behavior in first-party and third-party contexts?
+
+No.
+
+### 2.14 How do the features in this specification work in the context of a browser’s Private Browsing or Incognito mode?
+
+No difference to the browser's 'normal' state.
+
+### 2.15 Does this specification have both "Security Considerations" and "Privacy Considerations" sections?
+
+Combined together.
+
+### 2.16 Do features in your specification enable origins to downgrade default security protections?
+
+No.
+
+### 2.17 How does your feature handle non-"fully active" documents?
+
+Events are fired on active windows only.
+
+### 2.18 What should this questionnaire have asked?
+
+That's all. Thank you for your review.

--- a/security-privacy-self-assessment.md
+++ b/security-privacy-self-assessment.md
@@ -27,7 +27,7 @@ See 2.3.
 
 ### 2.5 Do the features in your specification introduce new state for an origin that persists across browsing sessions?
 
-No.
+This specification defines new [permissions](https://www.w3.org/TR/orientation-event/#permissions-api-integration) for which user agents may persist the user's decision to grant access to a site between browsing sessions. Otherwise, sensors are completely stateless. 
 
 ### 2.6 Do the features in your specification expose information about the underlying platform to origins?
 


### PR DESCRIPTION
This is a prerequisite for Privacy and Security reviews: https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review

@rakuco @reillyeon given you're on top of this specification I'm expecting you to help fill in this questionnaire. I pre-populated this doc with some content to help get the work started. I don't claim those responses to be complete or even accurate so I seek your expert review. Thank you for your contributions.

#125 is complementary material to help guide reviewers. I acknowledge that this specification last time reached its CR maturity in 2016 and at that time this self-assessment was not required, and we don't have a prior record. However, we have completed these reviews and done self-assessment for the Generic Sensor family of specs in 2018 which can be reused for its applicable parts for this review. I provided links to those self-assessments in this doc.