### PR TITLE
editorial: Fix grammar and missing words in Permissions Policy note

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -235,8 +235,8 @@ This specification defines the following <a>policy-controlled features</a>:
 <span class="marker">Note:</span> Usage of the <a>policy-controlled features</a> above by this specification is as follows:
 
   - The <a event for="Window"><code>deviceorientation</code></a> event requires the "<a data-lt="accelerometer-feature"><code>accelerometer</code></a>" and "<a data-lt="gyroscope-feature"><code>gyroscope</code></a>" features when providing <a>relative orientation</a> data. For the implementation to fall back to <a>absolute orientation</a> data, the "<a data-lt="magnetometer-feature"><code>magnetometer</code></a>" feature is also used.
-  - The <a event for="Window"><code>deviceorientationabsolute</code></a> event requires the "<a data-lt="accelerometer-feature"><code>accelerometer</code></a>", "<a data-lt="gyroscope-feature"><code>gyroscope</code></a>" and "<a data-lt="magnetometer-feature"><code>magnetometer</code></a>" feature.
-  - The <a event for="Window"><code>devicemotion</code></a> event requires the "<a data-lt="accelerometer-feature"><code>accelerometer</code></a>" and "<a data-lt="gyroscope-feature"><code>gyroscope</code></a>".
+  - The <a event for="Window"><code>deviceorientationabsolute</code></a> event requires the "<a data-lt="accelerometer-feature"><code>accelerometer</code></a>", "<a data-lt="gyroscope-feature"><code>gyroscope</code></a>" and "<a data-lt="magnetometer-feature"><code>magnetometer</code></a>" features.
+  - The <a event for="Window"><code>devicemotion</code></a> event requires the "<a data-lt="accelerometer-feature"><code>accelerometer</code></a>" and "<a data-lt="gyroscope-feature"><code>gyroscope</code></a>" features.
 
 </div>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 30, 2024, 12:44 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fdeviceorientation%2F206ded8a8c0b9a1d3b07d116180e69272f4983d2%2Findex.bs&force=1&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/deviceorientation%23134.)._
</details>
