### PR TITLE
Replace same-origin Security & Privacy requirement with Permissions Policy one

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -636,7 +636,7 @@ In light of that, implementations may consider visual indicators to signify the 
 Furthermore, to minimize privacy risks, the chance of fingerprinting and other attacks the implementations must:
 
 * fire events only when a [=/navigable=]'s [=navigable/active document=]'s [=visibility state=] is "<code>visible</code>",
-* fire events only on the [=/top-level traversable=]'s [=navigable/active window=] and [=child navigables=]' [=navigable/active windows=] whose [=relevant settings object=]'s [=environment settings object/origin=] is [=same origin=] with the [=/top-level traversable=]'s [=navigable/active window=]'s [=relevant settings object=]'s [=environment settings object/origin=].
+* implement [[#permissions-policy-integration]] so that events are fired on [=child navigables=] (including but not restricted to cross-origin ones) only if allowed by the [=/top-level traversable=],
 * fire events on a [=/navigable=]'s [=navigable/active windows=] only when its [=relevant settings object=] is a [=secure context=],
 * limit precision of attribute values as described in the previous sections.
 


### PR DESCRIPTION
This addresses a conflict that was introduced in #121:

- The presence of the Permissions Policy integration means usage of the
  Device Orientation API can be allowed in third-party iframes provided that
  the right tokens are in place.
- The "Security and privacy considerations" section contains a requirement
  that events are fired only on child navigables that are same-origin with
  the top-level traversable.

The latter was introduced in #25 and served as a stop-gap measure before
Permissions Policy integration was added.

The current implementation status is:
- Blink never implemented the same-origin requirement, but added Permissions
  Policy integration in 2018.
- WebKit has always implemented Permissions Policy integration.
- Gecko implements the same-origin requirement (see Mozilla bug 1197901).

This means we can safely replace the same-origin requirement with a
requirement to support the Permissions Policy integration, as switching from
one to the other is transparent in the sense that the exact same set of
websites that worked before will continue to work with the change, as the
features we define have a default allowlist of "self".

Fixes #133


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/pull/136.html" title="Last updated on Jan 31, 2024, 10:27 AM UTC (2fde787)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/136/e778bf8...2fde787.html" title="Last updated on Jan 31, 2024, 10:27 AM UTC (2fde787)">Diff</a>