### PR TITLE
DeviceOrientationEvent: Define absolute's value on error

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -388,10 +388,9 @@ Whenever a <a>significant change in orientation</a> occurs, the user agent must 
 
 <!--
   * https://github.com/w3c/deviceorientation/issues/118: Does this mean a single event should be fired?
-  * https://github.com/w3c/deviceorientation/issues/119: Should absolute's value be set here too?
   * Should this be a proper <dfn> in an algorithm?
 -->
-If an implementation can never provide orientation information, the event should be fired with the {{DeviceOrientationEvent/alpha}}, {{DeviceOrientationEvent/beta}} and {{DeviceOrientationEvent/gamma}} attributes set to null.
+If an implementation can never provide orientation information, the event should be fired with the {{DeviceOrientationEvent/alpha}}, {{DeviceOrientationEvent/beta}} and {{DeviceOrientationEvent/gamma}} attributes set to null, and the {{DeviceOrientationEvent/absoltue}} set to false.
 
 <h3 id="deviceorientationabsolute">deviceorientationabsolute Event</h3>
 
@@ -418,10 +417,9 @@ Whenever a <a>significant change in orientation</a> occurs, the user agent must 
 
 <!--
   * https://github.com/w3c/deviceorientation/issues/118: Does this mean a single event should be fired?
-  * https://github.com/w3c/deviceorientation/issues/119: Should absolute's value be set here too?
   * Should this be a proper <dfn> in an algorithm?
 -->
-If an implementation can never provide absolute orientation information, the event should be fired with the {{DeviceOrientationEvent/alpha}}, {{DeviceOrientationEvent/beta}} and {{DeviceOrientationEvent/gamma}} attributes set to null.
+If an implementation can never provide absolute orientation information, the event should be fired with the {{DeviceOrientationEvent/alpha}}, {{DeviceOrientationEvent/beta}} and {{DeviceOrientationEvent/gamma}} attributes set to null, and the {{DeviceOrientationEvent/absoltue}} set to true.
 
 <h3 id="devicemotion">devicemotion Event</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -390,7 +390,7 @@ Whenever a <a>significant change in orientation</a> occurs, the user agent must 
   * https://github.com/w3c/deviceorientation/issues/118: Does this mean a single event should be fired?
   * Should this be a proper <dfn> in an algorithm?
 -->
-If an implementation can never provide orientation information, the event should be fired with the {{DeviceOrientationEvent/alpha}}, {{DeviceOrientationEvent/beta}} and {{DeviceOrientationEvent/gamma}} attributes set to null, and the {{DeviceOrientationEvent/absoltue}} set to false.
+If an implementation can never provide orientation information, the event should be fired with the {{DeviceOrientationEvent/alpha}}, {{DeviceOrientationEvent/beta}} and {{DeviceOrientationEvent/gamma}} attributes set to null, and the {{DeviceOrientationEvent/absolute}} attribute set to false.
 
 <h3 id="deviceorientationabsolute">deviceorientationabsolute Event</h3>
 
@@ -419,7 +419,7 @@ Whenever a <a>significant change in orientation</a> occurs, the user agent must 
   * https://github.com/w3c/deviceorientation/issues/118: Does this mean a single event should be fired?
   * Should this be a proper <dfn> in an algorithm?
 -->
-If an implementation can never provide absolute orientation information, the event should be fired with the {{DeviceOrientationEvent/alpha}}, {{DeviceOrientationEvent/beta}} and {{DeviceOrientationEvent/gamma}} attributes set to null, and the {{DeviceOrientationEvent/absoltue}} set to true.
+If an implementation can never provide absolute orientation information, the event should be fired with the {{DeviceOrientationEvent/alpha}}, {{DeviceOrientationEvent/beta}} and {{DeviceOrientationEvent/gamma}} attributes set to null, and the {{DeviceOrientationEvent/absolute}} attribute set to true.
 
 <h3 id="devicemotion">devicemotion Event</h3>
 


### PR DESCRIPTION
We were only requiring alpha, beta, and gamma to be null. It makes sense to
also require implementations to set absolute to the same value as well.

At the time of writing, this is done for completeness' sake though:
- Blink implements this behavior and sets absolute to false when a
  deviceorientation cannot be provided, and to true for
  deviceorientationabsolute events.
- Gecko does not send any events if it cannot provide readings (e.g. when
  there are no sensors available).
- WebKit only ships an iOS implementation, whose IDL does not even have an
  absolute attribute.

Fixes #119.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/pull/139.html" title="Last updated on Feb 14, 2024, 8:01 AM UTC (1607c06)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/139/36b567e...1607c06.html" title="Last updated on Feb 14, 2024, 8:01 AM UTC (1607c06)">Diff</a>