### PR TITLE
Make DeviceMotionEventInit members nullable with null default

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -507,9 +507,9 @@ dictionary DeviceMotionEventRotationRateInit {
 };
 
 dictionary DeviceMotionEventInit : EventInit {
-    DeviceMotionEventAccelerationInit acceleration;
-    DeviceMotionEventAccelerationInit accelerationIncludingGravity;
-    DeviceMotionEventRotationRateInit rotationRate;
+    DeviceMotionEventAccelerationInit? acceleration = null;
+    DeviceMotionEventAccelerationInit? accelerationIncludingGravity = null;
+    DeviceMotionEventRotationRateInit? rotationRate = null;
     double interval = 0;
 };
 </pre>


### PR DESCRIPTION
This change reverts #55 and defines the default values of the DeviceMotionEventInit as null as I believe was the original intent of the definition before that change.

Null DeviceMotionEvent attributes have semantic meaning (they declare that the host does not provide the given sensor) and so script should be able to initialize an event with its attributes set to null.

Fixed #91.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/pull/141.html" title="Last updated on Feb 28, 2024, 10:44 PM UTC (dbdf9c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/141/c0f629e...dbdf9c4.html" title="Last updated on Feb 28, 2024, 10:44 PM UTC (dbdf9c4)">Diff</a>