### PR TITLE
Editorial: small fixup to Device Motion section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -219,7 +219,7 @@ Acceleration is the rate of change of velocity of a device with respect to time.
 
 <dfn local-lt="linear acceleration">Linear device acceleration</dfn> represents the device's acceleration rate without the contribution of the gravity force. When the device is laying flat on a table, its <a>linear acceleration</a> is 0 m/s<sup>2</sup>.
 
-When the acceleration <dfn lt="acceleration with gravity">includes gravity</dfn>, its value includes the effect of gravity and represents <a href="https://en.wikipedia.org/wiki/Proper_acceleration">proper acceleration</a>. When the device is in free-fall, the acceleration is 0 m/s<sup>2</sup>. This is less useful in many applications but is provided as a means of providing best-effort support by implementations that are unable to provide <a>linear acceleration</a> (due, for example, to the lack of a gyroscope).
+When the acceleration <dfn lt="acceleration with gravity">includes gravity</dfn>, its value includes the effect of gravity and represents proper acceleration [[PROPERACCELERATION]]. When the device is in free-fall, the acceleration is 0 m/s<sup>2</sup>. This is less useful in many applications but is provided as a means of providing best-effort support by implementations that are unable to provide <a>linear acceleration</a> (due, for example, to the lack of a gyroscope).
 
 Note: In practice, <a>acceleration with gravity</a> represents the raw readings obtained from an [[MOTION-SENSORS#accelerometer]], or the [[G-FORCE]] whereas <a>linear acceleration</a> provides the readings of a [[MOTION-SENSORS#linear-acceleration-sensor]] and is likely a fusion sensor. [[MOTION-SENSORS]] and [[ACCELEROMETER]] both contain a more detailed discussion about the different types of accelerometers and accelerations that can be measured.
 
@@ -1067,6 +1067,10 @@ urlPrefix: https://html.spec.whatwg.org/multipage/
     "GIMBALLOCK": {
         "href": "https://en.wikipedia.org/wiki/Gimbal_Lock",
         "title": "Gimbal Lock"
+    },
+   "PROPERACCELERATION": {
+        "href": "https://en.wikipedia.org/wiki/Proper_acceleration",
+        "title": "Proper acceleration"
     },
     "QUATERNIONS": {
         "href": "https://en.wikipedia.org/wiki/Quaternion",

--- a/index.bs
+++ b/index.bs
@@ -1068,7 +1068,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/
         "href": "https://en.wikipedia.org/wiki/Gimbal_Lock",
         "title": "Gimbal Lock"
     },
-   "PROPERACCELERATION": {
+    "PROPERACCELERATION": {
         "href": "https://en.wikipedia.org/wiki/Proper_acceleration",
         "title": "Proper acceleration"
     },

--- a/index.bs
+++ b/index.bs
@@ -219,7 +219,7 @@ Acceleration is the rate of change of velocity of a device with respect to time.
 
 <dfn local-lt="linear acceleration">Linear device acceleration</dfn> represents the device's acceleration rate without the contribution of the gravity force. When the device is laying flat on a table, its <a>linear acceleration</a> is 0 m/s<sup>2</sup>.
 
-When the acceleration <dfn lt="acceleration with gravity">includes gravity</dfn>, its value includes the effect of gravity and represents proper acceleration [[PROPERACCELERATION]]. When the device is in free-fall, the acceleration is 0 m/s<sup>2</sup>. This is less useful in many applications but is provided as a means of providing best-effort support by implementations that are unable to provide <a>linear acceleration</a> (due, for example, to the lack of a gyroscope).
+When the acceleration <dfn lt="acceleration with gravity">includes gravity</dfn>, its value includes the effect of gravity and represents proper acceleration ([[PROPERACCELERATION]]). When the device is in free-fall, the acceleration is 0 m/s<sup>2</sup>. This is less useful in many applications but is provided as a means of providing best-effort support by implementations that are unable to provide <a>linear acceleration</a> (due, for example, to the lack of a gyroscope).
 
 Note: In practice, <a>acceleration with gravity</a> represents the raw readings obtained from an [[MOTION-SENSORS#accelerometer]], or the [[G-FORCE]] whereas <a>linear acceleration</a> provides the readings of a [[MOTION-SENSORS#linear-acceleration-sensor]] and is likely a fusion sensor. [[MOTION-SENSORS]] and [[ACCELEROMETER]] both contain a more detailed discussion about the different types of accelerometers and accelerations that can be measured.
 

--- a/index.bs
+++ b/index.bs
@@ -202,7 +202,7 @@ Note: This choice of angles follows mathematical convention, but means that alph
 
 A device's orientation is always relative to another coordinate system, whose choice influences the kind of information that the orientation conveys as well as the source of the orientation data.
 
-<dfn>Relative orientation</dfn> is measured with an accelerometer and a gyroscope, and the reference coordinate system is arbitrary. Consequently, the orientation data provides information about changes relative to the initial position of the device.
+<dfn local-lt="relative orientation">Relative device orientation</dfn> is measured with an accelerometer and a gyroscope, and the reference coordinate system is arbitrary. Consequently, the orientation data provides information about changes relative to the initial position of the device.
 
 Note: In native platform terms, this is similar to a relative <a href="https://learn.microsoft.com/en-us/uwp/api/windows.devices.sensors.sensorreadingtype#remarks">OrientationSensor</a> on Windows, a <a href="https://developer.android.com/reference/android/hardware/Sensor#TYPE_GAME_ROTATION_VECTOR">game rotation vector sensor</a> on Android, or the <a href="https://developer.apple.com/documentation/coremotion/cmattitudereferenceframe/1615953-xarbitraryzvertical">xArbitraryZVertical</a> option for Core Motion.
 
@@ -217,9 +217,9 @@ This specification expresses a device's motion in space by measuring its acceler
 
 Acceleration is the rate of change of velocity of a device with respect to time. Is is expressed in meters per second squared (m/s<sup>2</sup>).
 
-<dfn>Linear acceleration</dfn> represents the device's acceleration rate without the contribution of the gravity force. When the device is laying flat on a table, its <a>linear acceleration</a> is 0 m/s<sup>2</sup>.
+<dfn local-lt="linear acceleration">Linear device acceleration</dfn> represents the device's acceleration rate without the contribution of the gravity force. When the device is laying flat on a table, its <a>linear acceleration</a> is 0 m/s<sup>2</sup>.
 
-When the acceleration <dfn lt="acceleration with gravity">includes gravity</dfn>, its value includes the effect of gravity and represents proper acceleration ([[PROPERACCELERATION]]). When the device is in free-fall, the acceleration is 0 m/s<sup>2</sup>. This is less useful in many applications but is provided as a means of providing best-effort support by implementations that are unable to provide <a>linear acceleration</a> (due, for example, to the lack of a gyroscope).
+When the acceleration <dfn lt="acceleration with gravity">includes gravity</dfn>, its value includes the effect of gravity and represents <a href="https://en.wikipedia.org/wiki/Proper_acceleration">proper acceleration</a>. When the device is in free-fall, the acceleration is 0 m/s<sup>2</sup>. This is less useful in many applications but is provided as a means of providing best-effort support by implementations that are unable to provide <a>linear acceleration</a> (due, for example, to the lack of a gyroscope).
 
 Note: In practice, <a>acceleration with gravity</a> represents the raw readings obtained from an [[MOTION-SENSORS#accelerometer]], or the [[G-FORCE]] whereas <a>linear acceleration</a> provides the readings of a [[MOTION-SENSORS#linear-acceleration-sensor]] and is likely a fusion sensor. [[MOTION-SENSORS]] and [[ACCELEROMETER]] both contain a more detailed discussion about the different types of accelerometers and accelerations that can be measured.
 
@@ -1067,10 +1067,6 @@ urlPrefix: https://html.spec.whatwg.org/multipage/
     "GIMBALLOCK": {
         "href": "https://en.wikipedia.org/wiki/Gimbal_Lock",
         "title": "Gimbal Lock"
-    },
-    "PROPERACCELERATION": {
-        "href": "https://en.wikipedia.org/wiki/Proper_acceleration",
-        "title": "Proper acceleration"
     },
     "QUATERNIONS": {
         "href": "https://en.wikipedia.org/wiki/Quaternion",


### PR DESCRIPTION
Normative references to wikipedia is probably not ideal - specially for a general knowledge topic.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/pull/163.html" title="Last updated on May 7, 2024, 5:00 AM UTC (dba5559)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/163/21d1db5...dba5559.html" title="Last updated on May 7, 2024, 5:00 AM UTC (dba5559)">Diff</a>