### PR TITLE
Editorial: fix allowlist 'self' cross reference

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -236,9 +236,9 @@ This integration is [=at risk=] due to a lack of test coverage in Web Platform T
 
 This specification defines the following <a>policy-controlled features</a>:
 
-  - "<code><dfn export data-lt="accelerometer-feature">accelerometer</dfn></code>", whose <a>default allowlist</a> is "<code>self</code>".
-  - "<code><dfn export data-lt="gyroscope-feature">gyroscope</dfn></code>", whose <a>default allowlist</a> is "<code>self</code>".
-  - "<code><dfn export data-lt="magnetometer-feature">magnetometer</dfn></code>", whose <a>default allowlist</a> is "<code>self</code>".
+  - "<code><dfn export data-lt="accelerometer-feature">accelerometer</dfn></code>", whose <a>default allowlist</a> is [=default allowlist/'self'=].
+  - "<code><dfn export data-lt="gyroscope-feature">gyroscope</dfn></code>", whose <a>default allowlist</a> is [=default allowlist/'self'=].
+  - "<code><dfn export data-lt="magnetometer-feature">magnetometer</dfn></code>", whose <a>default allowlist</a> is [=default allowlist/'self'=].
 
 <div class="note">
 <span class="marker">Note:</span> Usage of the <a>policy-controlled features</a> above by this specification is as follows:


### PR DESCRIPTION
Should be 'self' not "self"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/pull/164.html" title="Last updated on May 2, 2024, 5:54 AM UTC (3f0dfb3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/164/37c29da...3f0dfb3.html" title="Last updated on May 2, 2024, 5:54 AM UTC (3f0dfb3)">Diff</a>