### PR TITLE
Editorial: change spec title

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: DeviceOrientation Event Specification
+Title: Device Orientation and Motion
 Shortname: orientation-event
 Level: none
 Status: ED


### PR DESCRIPTION
@reillyeon, I don't think we should include "Event"... in the title. The spec provides a Model for device orientation and motion, which then are expressed in the API as events. But like with other specs, (e.g., [Fetch](https://fetch.spec.whatwg.org), [Permissions](https://www.w3.org/TR/permissions/), [Screen orientation](https://www.w3.org/TR/screen-orientation), etc.) we generally wouldn't put how it's represented as the API in the title.

To be sure, if one Googles, Bings, or even searches on DuckDuckGo, for "device orientation and motion spec" the spec is already found - so this wouldn't affect how findable this spec is.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/pull/168.html" title="Last updated on May 3, 2024, 7:55 AM UTC (d3639dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/168/876932f...d3639dc.html" title="Last updated on May 3, 2024, 7:55 AM UTC (d3639dc)">Diff</a>