### PR TITLE
chore: fix link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Contributions to this repository are intended to become part of Recommendation-track documents governed by the
 [W3C Patent Policy](https://www.w3.org/Consortium/Patent-Policy/) and
-[Software and Document License](https://www.w3.org/Consortium/Legal/copyright-
-software). To make substantive contributions to specifications, you must either participate
+[Software and Document License](https://www.w3.org/Consortium/Legal/copyright-software). 
+To make substantive contributions to specifications, you must either participate
 in the relevant W3C Working Group or make a non-member patent licensing commitment.
 
 If you are not the sole contributor to a contribution (pull request), please identify all


### PR DESCRIPTION
Line break was breaking link to license