### PR TITLE
Revert "Process: Set CRS comment deadline to 2025-03-15"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -24,7 +24,6 @@ Markup Shorthands: css no
 Markup Shorthands: markdown yes
 text macro: JOINT yes
 text macro: JOINTWEBAPPS yes
-Deadline: 2025-03-15
 </pre>
 <pre class="anchors">
 urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR


### PR DESCRIPTION
The upstream Bikeshed issue which required a deadline for a CRD rather than a CRS has been fixed.

This reverts commit 5adbbea4a21d004927f33e40ff4d5a70cc85de73.

Closes #???


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/pull/192.html" title="Last updated on Feb 12, 2025, 9:07 PM UTC (dd52503)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/deviceorientation/192/5adbbea...dd52503.html" title="Last updated on Feb 12, 2025, 9:07 PM UTC (dd52503)">Diff</a>